### PR TITLE
SHORT_BONE_INDICES type support

### DIFF
--- a/flver.py
+++ b/flver.py
@@ -285,6 +285,8 @@ class VertexBufferStructMember:
             uv = struct.unpack_from("hhhh", buf, offset)
             return tuple(component / uv_divisor for component in uv)
         
+        if self.data_type == self.DataType.SHORT_BONE_INDICES:
+            return tuple(struct.unpack_from("hhhh", buf, offset))
         raise Exception(f'Unsupported type {self.data_type}')
 
         


### PR DESCRIPTION
Added support for SHORT_BONE_INDICES data type.
Absolutely no idea what it is designed for and where it is used, for sure it should be divided by some divisor like the BYTE4A, BYTE4C, UV and UV_PAIR.
But this fix at least prevents the plug-in from crashing and imports the model successfuly.
As example, the ER Fire Giant 'c4760.chrbnd.dcx' had crashes related to the SHORT_BONE_INDICES data type.